### PR TITLE
sci-libs/pytorch: fix python and update rocm support

### DIFF
--- a/sci-libs/pytorch/files/pytorch-1.9.0-Change-library-directory-according-to-CMake-build.patch
+++ b/sci-libs/pytorch/files/pytorch-1.9.0-Change-library-directory-according-to-CMake-build.patch
@@ -1,0 +1,32 @@
+From 52019a3f395e5fa97b26d424152d91f73b400f8e Mon Sep 17 00:00:00 2001
+From: Alexey Chernov <4ernov@gmail.com>
+Date: Wed, 13 Nov 2019 23:44:12 +0300
+Subject: [PATCH 5/5] Change library directory according to CMake build
+Modified: Tue, 03 Aug 2021, fit for pytorch-1.9.0
+
+Change `lib_path` in favour of out-of-tree CMake build
+directory, so that all the C++ libraries be found.
+---
+ setup.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 60502b6add..cbced52192 100644
+--- a/setup.py
++++ b/setup.py
+@@ -268,9 +268,10 @@ else:
+ 
+ # Constant known variables used throughout this file
+ cwd = os.path.dirname(os.path.abspath(__file__))
+-lib_path = os.path.join(cwd, "torch", "lib")
++cmake_build_dir = os.environ.get("CMAKE_BUILD_DIR", os.path.join(cwd, "build"))
++lib_path = os.path.join(cmake_build_dir, "lib")
+ third_party_path = os.path.join(cwd, "third_party")
+-caffe2_build_dir = os.path.join(cwd, "build")
++caffe2_build_dir = cmake_build_dir
+ 
+ # CMAKE: full path to python library
+ if IS_WINDOWS:
+-- 
+2.23.0
+

--- a/sci-libs/pytorch/files/pytorch-1.9.1-fix-wrong-hipify.patch
+++ b/sci-libs/pytorch/files/pytorch-1.9.1-fix-wrong-hipify.patch
@@ -1,0 +1,13 @@
+The hipify misadd a ) and causes compilation error
+
+--- orig/aten/src/ATen/native/sparse/hip/SparseHIPTensor.hip
++++ pytorch-1.9.1/aten/src/ATen/native/sparse/hip/SparseHIPTensor.hip
+@@ -282,7 +282,7 @@ Tensor sparse_mask_helper_cuda(
+               mask_indices_ti,
+               t_indices_pos_ti,
+               t_values_ti,
+-              r_values_ti);
++              r_values_ti;
+           C10_HIP_KERNEL_LAUNCH_CHECK();
+         });
+   }


### PR DESCRIPTION
Other changes:

1. Pytorch seems to be work fine with different version of protobuf, so
   no need to specify 0/30; however when protobuf version changed torch
   should be rebuilt.

2. BUILD_NAMEDTENSOR is not an option now

3. Verbose mode for rm in src_install

Package-Manager: Portage-3.0.22, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>